### PR TITLE
Removes PDF button when using shortcode

### DIFF
--- a/includes/class-dkpdf-settings.php
+++ b/includes/class-dkpdf-settings.php
@@ -170,7 +170,7 @@ class DKPDF_Settings {
 					'label'			=> __( 'Position', 'dkpdf' ),
 					'description'	=> '',
 					'type'			=> 'radio',
-					'options'		=> array( 'before' => 'Before content', 'after' => 'After content' ),
+					'options'		=> array( 'shortcode' => 'Use shortcode', 'before' => 'Before content', 'after' => 'After content' ),
 					'default'		=> 'before'
 				),
 				array(

--- a/includes/dkpdf-functions.php
+++ b/includes/dkpdf-functions.php
@@ -65,6 +65,10 @@ function dkpdf_display_pdf_button( $content ) {
 
         if( $pdfbutton_position ) {
 
+            if ( $pdfbutton_position == 'shortcode' ) {
+              return $c;
+            }
+
             if( $pdfbutton_position == 'before' ) {
 
               ob_start();


### PR DESCRIPTION
Here is the problem, if I want to put my PDF button in a custom location in my theme, currently a non-dev user can't remove the PDF from the before the content position.

This PR gives the user an option and more flexibility of where he wants to use the PDF button.
