### PR TITLE
Add filter to change PDF Filename (dkpdf_pdf_title)

### DIFF
--- a/includes/dkpdf-functions.php
+++ b/includes/dkpdf-functions.php
@@ -161,18 +161,18 @@ function dkpdf_output_pdf( $query ) {
       $mpdf->WriteHTML( dkpdf_get_template( 'dkpdf-index' ) );
       $mpdf->WriteHTML( apply_filters( 'dkpdf_after_content', '' ) );
 
-      // action to do (open or download)
+       // action to do (open or download)
+      global $post;
       $pdfbutton_action = sanitize_option( 'dkpdf_pdfbutton_action', get_option( 'dkpdf_pdfbutton_action', 'open' ) );
-
+	    $pdf_title = apply_filters( 'dkpdf_pdf_title', get_the_title( $post->ID ) );
+	  
       if( $pdfbutton_action == 'open') {
 
-        global $post;
-        $mpdf->Output( get_the_title( $post->ID ).'.pdf', 'I' );
+        $mpdf->Output( $pdf_title.'.pdf', 'I' );
 
       } else {
 
-        global $post;
-        $mpdf->Output( get_the_title( $post->ID ).'.pdf', 'D' );
+        $mpdf->Output( $pdf_title.'.pdf', 'D' );
 
       }
 

--- a/includes/dkpdf-functions.php
+++ b/includes/dkpdf-functions.php
@@ -164,7 +164,7 @@ function dkpdf_output_pdf( $query ) {
        // action to do (open or download)
       global $post;
       $pdfbutton_action = sanitize_option( 'dkpdf_pdfbutton_action', get_option( 'dkpdf_pdfbutton_action', 'open' ) );
-	    $pdf_title = apply_filters( 'dkpdf_pdf_title', get_the_title( $post->ID ) );
+      $pdf_title = apply_filters( 'dkpdf_pdf_title', get_the_title( $post->ID ) );
 	  
       if( $pdfbutton_action == 'open') {
 

--- a/includes/dkpdf-shortcodes.php
+++ b/includes/dkpdf-shortcodes.php
@@ -45,6 +45,22 @@ function dkpdf_remove_shortcode( $atts, $content = null ) {
 add_shortcode( 'dkpdf-remove', 'dkpdf_remove_shortcode' );
 
 /**
+* [dkpdf-add]content to add[/dkpdf-add]
+* This shortcode is used to add pieces of content in the generated PDF
+* @return string
+*/
+function dkpdf_add_shortcode( $atts, $content = null ) {
+	$atts = shortcode_atts( array(), $atts );
+	$pdf = get_query_var( 'pdf' );
+
+	if( $pdf )
+		return do_shortcode( $content );
+	
+	return '';
+}
+add_shortcode( 'dkpdf-add', 'dkpdf_add_shortcode' );
+
+/**
 * [dkpdf-pagebreak]
 * Allows adding page breaks for sending content after this shortcode to the next page.
 * Uses <pagebreak /> http://mpdf1.com/manual/index.php?tid=108


### PR DESCRIPTION
this filters allows to change the PDF download title.

i did this because the title was realy cracked up with special chars.

my filter example in functions.php:

`function changing_dkpdf_pdf_title( $title ) {`
`      global $post;`
`      $title = get_bloginfo( 'name' ).'-'.$post->post_name.'-SUFFIX';`
`      return ucwords( sanitize_title($title), " -");`
`}`
`add_filter( 'dkpdf_pdf_title', 'changing_dkpdf_pdf_title' );`