### PR TITLE
Add a cache subsystem

### DIFF
--- a/includes/class-dkpdf-settings.php
+++ b/includes/class-dkpdf-settings.php
@@ -52,6 +52,11 @@ class DKPDF_Settings {
 		// Addons submenu
 		add_submenu_page( 'dkpdf' . '_settings', 'Addons', 'Addons', 'manage_options', 'dkpdf-addons', array( $this, 'dkpdf_addons_screen' ));
 
+		// Clear cache submenu
+		if( dkpdf_cache_is_enabled() ) {
+			add_submenu_page( 'dkpdf' . '_settings', 'Clear Cache', 'Clear Cache', 'manage_options', 'dkpdf-cache', array( $this, 'dkpdf_cache_screen' ));
+		}
+
 		// support
 		add_submenu_page( 'dkpdf' . '_settings', 'Support', 'Support', 'manage_options', 'dkpdf-support', array( $this, 'dkpdf_support_screen' ));
 
@@ -92,6 +97,31 @@ class DKPDF_Settings {
 				<p>Allows creating PDF documents with your selected WordPress content, also allows adding a Cover and a Table of contents.</p>
 				<p><a href="http://codecanyon.net/item/dk-pdf-generator/13530581" target="_blank">Go to DK PDF Generator</a></p>
 			</div>
+
+		</div>
+
+	<?php }
+
+	public function dkpdf_cache_screen() { ?>
+<?php if( $_SERVER['REQUEST_METHOD'] == 'POST' ) {
+			$num_flushed = dkpdf_cache_flush();
+?>
+			<div id="message" class="updated">
+					<p><?php _e($num_flushed . ' PDF file(s) deleted from cache.', 'dkpdf');?></p>
+			</div>
+<?php    } ?>
+
+		<div class="wrap">
+			<h2>Clear PDF cache</h2>
+
+<?php if( dkpdf_cache_is_enabled() ) { ?>
+			<p>Click the button below to delete all cached PDF files. </p>
+			<form method="POST">
+				<input class="button-primary" name="Submit" value="Flush All PDF Files From Cache" type="submit" />
+			</form>
+<?php } else { ?>
+			<p>DK PDF cache is disabled, please go to DK PDF Settings - PDF Setup - Enable PDF cache to enable it.</p>
+<?php } ?>
 
 		</div>
 

--- a/includes/class-dkpdf-settings.php
+++ b/includes/class-dkpdf-settings.php
@@ -265,6 +265,13 @@ class DKPDF_Settings {
 					'type'			=> 'checkbox',
 					'default'		=> ''
 				),
+				array(
+					'id' 			=> 'enable_cache',
+					'label'			=> __( 'Enable PDF cache', 'dkpdf' ),
+					'description'	=> 'PDF files will not be generated on every view, an on-disk cache will be created instead.',
+					'type'			=> 'checkbox',
+					'default'		=> ''
+				),
 			)
 		);
 

--- a/includes/class-dkpdf-settings.php
+++ b/includes/class-dkpdf-settings.php
@@ -183,6 +183,7 @@ class DKPDF_Settings {
 			)
 		);
 
+		$cache_force_enabled = (defined('DKPDF_CACHE') && (DKPDF_CACHE == 'on' || DKPDF_CACHE === true)) ? 'WARNING: <b>DKPDF_CACHE</b> defined in wp-config.php, this setting is forced to "on". ' : '';
 
 		// pdf setup
 		$settings['dkpdf_setup'] = array(
@@ -270,9 +271,9 @@ class DKPDF_Settings {
 				array(
 					'id' 			=> 'enable_cache',
 					'label'			=> __( 'Enable PDF cache', 'dkpdf' ),
-					'description'	=> 'PDF files will not be generated on every view, an on-disk cache will be created instead.',
+					'description'	=> $cache_force_enabled ? $cache_force_enabled : 'PDF files will not be generated on every view, an on-disk cache will be created instead.',
 					'type'			=> 'checkbox',
-					'default'		=> ''
+					'default'		=> $cache_force_enabled ? 'on' : ''
 				),
 			)
 		);

--- a/includes/class-dkpdf-settings.php
+++ b/includes/class-dkpdf-settings.php
@@ -2,6 +2,8 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
+require_once('dkpdf-cache.php');
+
 class DKPDF_Settings {
 
 	private static $_instance = null;
@@ -413,9 +415,11 @@ class DKPDF_Settings {
 	 */
 	public function settings_page () {
 
-		if( isset( $_GET['settings-updated']) ) { ?>
+		if( isset( $_GET['settings-updated']) ) { 
+			dkpdf_cache_flush();
+			?>
 		    <div id="message" class="updated">
-		        <p><?php _e('Settings saved.', 'dkpdf');?></p>
+		        <p><?php _e('Settings saved. PDF cache flushed.', 'dkpdf');?></p>
 		    </div>
 		<?php }
 

--- a/includes/dkpdf-cache.php
+++ b/includes/dkpdf-cache.php
@@ -18,7 +18,13 @@ function dkpdf_cache_init() {
 		mkdir( DKPDF_CACHE_DIR, 0750, TRUE );
 	}
 
-	return is_writable( DKPDF_CACHE_DIR );
+	$result = is_writable( DKPDF_CACHE_DIR );
+
+	if( !$result ) {
+		error_log( 'Could not initialize DK-PDF cache: ' . DKPDF_CACHE_DIR . ' is not writable by PHP' );
+	}
+
+	return $result;
 }
 
 function dkpdf_cache_path( $post_id ) {

--- a/includes/dkpdf-cache.php
+++ b/includes/dkpdf-cache.php
@@ -1,0 +1,41 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+define('DKPDF_CACHE_DIR', WP_CONTENT_DIR . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR . 'dkpdf');
+
+function dkpdf_cache_init() {
+	if( !is_dir(DKPDF_CACHE_DIR) ) {
+		mkdir(DKPDF_CACHE_DIR, 0750, TRUE);
+	}
+
+	return is_writable(DKPDF_CACHE_DIR);
+}
+
+function dkpdf_cache_path($post_id) {
+	return DKPDF_CACHE_DIR . DIRECTORY_SEPARATOR . hash('sha256', 'dkpdf_' . $post_id . '_' . LOGGED_IN_SALT) . '.pdf';
+}
+
+function dkpdf_cache_get($post_id) {
+
+	if( !dkpdf_cache_init() ) {
+		return false;
+	}
+
+	$path = dkpdf_cache_path($post_id);
+	if( !is_readable($path) ) {
+		return false;
+	}
+
+	return file_get_contents($path);
+}
+
+function dkpdf_cache_set($post_id, $data) {
+
+	if(!dkpdf_cache_init()) {
+		return false;
+	}
+
+	$path = dkpdf_cache_path($post_id);
+	return file_put_contents($path, $data);
+}

--- a/includes/dkpdf-cache.php
+++ b/includes/dkpdf-cache.php
@@ -4,6 +4,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 define('DKPDF_CACHE_DIR', WP_CONTENT_DIR . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR . 'dkpdf');
 
+add_action('save_post', 'dkpdf_cache_unset');
+
 function dkpdf_cache_init() {
 	if( !is_dir(DKPDF_CACHE_DIR) ) {
 		mkdir(DKPDF_CACHE_DIR, 0750, TRUE);
@@ -38,4 +40,37 @@ function dkpdf_cache_set($post_id, $data) {
 
 	$path = dkpdf_cache_path($post_id);
 	return file_put_contents($path, $data);
+}
+
+function dkpdf_cache_unset($post_id) {
+
+	if(!dkpdf_cache_init()) {
+		return false;
+	}
+
+	$path = dkpdf_cache_path($post_id);
+
+	unlink($path);
+}
+
+/**
+ * Delete all PDFs from cache
+ */
+function dkpdf_cache_flush() {
+
+	if(!dkpdf_cache_init()) {
+		return;
+	}
+
+	$files = glob(DKPDF_CACHE_DIR . DIRECTORY_SEPARATOR . '*', GLOB_NOSORT | GLOB_MARK);
+  if( $files === false) {
+		return;
+	}
+
+	foreach( $files as $file ) {
+		if( strlen($file) == 0 || $file[strlen($file) - 1] == DIRECTORY_SEPARATOR ) {
+			continue;
+		}
+		unlink($file);
+	}
 }

--- a/includes/dkpdf-cache.php
+++ b/includes/dkpdf-cache.php
@@ -57,7 +57,9 @@ function dkpdf_cache_unset( $post_id ) {
 
 	$path = dkpdf_cache_path( $post_id );
 
-	unlink( $path );
+	if( is_file( $path ) ) {
+		unlink( $path );
+	}
 }
 
 /**
@@ -79,8 +81,10 @@ function dkpdf_cache_flush() {
 		if( strlen( $file ) == 0 || $file[strlen( $file ) - 1] == DIRECTORY_SEPARATOR ) {
 			continue;
 		}
-		unlink( $file );
-		$num_files++;
+		if( is_file( $path ) ) {
+			unlink( $file );
+			$num_files++;
+		}
 	}
 
 	return $num_files;

--- a/includes/dkpdf-cache.php
+++ b/includes/dkpdf-cache.php
@@ -2,55 +2,55 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define('DKPDF_CACHE_DIR', WP_CONTENT_DIR . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR . 'dkpdf');
+define( 'DKPDF_CACHE_DIR', WP_CONTENT_DIR . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR . 'dkpdf' );
 
-add_action('save_post', 'dkpdf_cache_unset');
+add_action( 'save_post', 'dkpdf_cache_unset' );
 
 function dkpdf_cache_init() {
-	if( !is_dir(DKPDF_CACHE_DIR) ) {
-		mkdir(DKPDF_CACHE_DIR, 0750, TRUE);
+	if( !is_dir( DKPDF_CACHE_DIR ) ) {
+		mkdir( DKPDF_CACHE_DIR, 0750, TRUE );
 	}
 
-	return is_writable(DKPDF_CACHE_DIR);
+	return is_writable( DKPDF_CACHE_DIR );
 }
 
-function dkpdf_cache_path($post_id) {
-	return DKPDF_CACHE_DIR . DIRECTORY_SEPARATOR . hash('sha256', 'dkpdf_' . $post_id . '_' . LOGGED_IN_SALT) . '.pdf';
+function dkpdf_cache_path( $post_id ) {
+	return DKPDF_CACHE_DIR . DIRECTORY_SEPARATOR . hash( 'sha256', 'dkpdf_' . $post_id . '_' . LOGGED_IN_SALT ) . '.pdf';
 }
 
-function dkpdf_cache_get($post_id) {
+function dkpdf_cache_get( $post_id ) {
 
 	if( !dkpdf_cache_init() ) {
 		return false;
 	}
 
-	$path = dkpdf_cache_path($post_id);
-	if( !is_readable($path) ) {
+	$path = dkpdf_cache_path( $post_id );
+	if( !is_readable( $path ) ) {
 		return false;
 	}
 
-	return file_get_contents($path);
+	return file_get_contents( $path );
 }
 
-function dkpdf_cache_set($post_id, $data) {
+function dkpdf_cache_set( $post_id, $data ) {
 
 	if(!dkpdf_cache_init()) {
 		return false;
 	}
 
-	$path = dkpdf_cache_path($post_id);
-	return file_put_contents($path, $data);
+	$path = dkpdf_cache_path( $post_id );
+	return file_put_contents( $path, $data );
 }
 
-function dkpdf_cache_unset($post_id) {
+function dkpdf_cache_unset( $post_id ) {
 
 	if(!dkpdf_cache_init()) {
 		return false;
 	}
 
-	$path = dkpdf_cache_path($post_id);
+	$path = dkpdf_cache_path( $post_id );
 
-	unlink($path);
+	unlink( $path );
 }
 
 /**
@@ -62,15 +62,15 @@ function dkpdf_cache_flush() {
 		return;
 	}
 
-	$files = glob(DKPDF_CACHE_DIR . DIRECTORY_SEPARATOR . '*', GLOB_NOSORT | GLOB_MARK);
-  if( $files === false) {
+	$files = glob( DKPDF_CACHE_DIR . DIRECTORY_SEPARATOR . '*', GLOB_NOSORT | GLOB_MARK );
+  if( $files === false ) {
 		return;
 	}
 
 	foreach( $files as $file ) {
-		if( strlen($file) == 0 || $file[strlen($file) - 1] == DIRECTORY_SEPARATOR ) {
+		if( strlen( $file ) == 0 || $file[strlen( $file ) - 1] == DIRECTORY_SEPARATOR ) {
 			continue;
 		}
-		unlink($file);
+		unlink( $file );
 	}
 }

--- a/includes/dkpdf-cache.php
+++ b/includes/dkpdf-cache.php
@@ -79,7 +79,7 @@ function dkpdf_cache_flush() {
 	}
 
 	$files = glob( DKPDF_CACHE_DIR . DIRECTORY_SEPARATOR . '*', GLOB_NOSORT | GLOB_MARK );
-  if( $files === false ) {
+	if( $files === false ) {
 		return;
 	}
 
@@ -87,8 +87,10 @@ function dkpdf_cache_flush() {
 		if( strlen( $file ) == 0 || $file[strlen( $file ) - 1] == DIRECTORY_SEPARATOR ) {
 			continue;
 		}
-		if( is_file( $path ) ) {
-			unlink( $file );
+
+		$deleted = @unlink( $file );
+
+		if( $deleted ) {
 			$num_files++;
 		}
 	}

--- a/includes/dkpdf-cache.php
+++ b/includes/dkpdf-cache.php
@@ -64,6 +64,7 @@ function dkpdf_cache_unset( $post_id ) {
  * Delete all PDFs from cache
  */
 function dkpdf_cache_flush() {
+	$num_files = 0;
 
 	if(!dkpdf_cache_init()) {
 		return;
@@ -79,7 +80,10 @@ function dkpdf_cache_flush() {
 			continue;
 		}
 		unlink( $file );
+		$num_files++;
 	}
+
+	return $num_files;
 }
 
 /* 

--- a/includes/dkpdf-cache.php
+++ b/includes/dkpdf-cache.php
@@ -5,6 +5,13 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 define( 'DKPDF_CACHE_DIR', WP_CONTENT_DIR . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR . 'dkpdf' );
 
 add_action( 'save_post', 'dkpdf_cache_unset' );
+add_action( 'sidebar_admin_setup', 'dkpdf_cache_sidebar_flush' );
+
+function dkpdf_cache_is_enabled() {
+	/* define('DKPDF_CACHE', 'on') in wp-config.php saves a few seconds compared to just ticking the box in options */
+	$enabled = defined('DKPDF_CACHE') ? DKPDF_CACHE : get_option( 'dkpdf_enable_cache' );
+	return ($enabled == "on" or $enabled === true);
+}
 
 function dkpdf_cache_init() {
 	if( !is_dir( DKPDF_CACHE_DIR ) ) {
@@ -73,4 +80,11 @@ function dkpdf_cache_flush() {
 		}
 		unlink( $file );
 	}
+}
+
+/* 
+ * Flush cache when saving sidebar widgets 
+ */
+function dkpdf_cache_sidebar_flush() {
+	error_log('dkpdf_cache_sidebar_flush, method: ' . $_SERVER['REQUEST_METHOD'] . ' url ' . $_SERVER['REQUEST_URI']);
 }

--- a/includes/dkpdf-functions.php
+++ b/includes/dkpdf-functions.php
@@ -115,6 +115,8 @@ function dkpdf_output_pdf( $query ) {
 			global $post;
       $enable_cache = dkpdf_cache_is_enabled();
 
+			ini_set('display_errors', 0);
+
       if( $enable_cache ) {
 
 				if($data = dkpdf_cache_get($post->ID)) {
@@ -122,6 +124,7 @@ function dkpdf_output_pdf( $query ) {
 					$title = str_replace( '"', '', apply_filters( 'dkpdf_pdf_filename', get_the_title( $post->ID ) ) );
 					$name = $title . '.pdf';
 
+					http_response_code(200);
 					if( $pdfbutton_action == 'open' ) {
 						header('Content-Type: application/pdf');
 

--- a/includes/dkpdf-functions.php
+++ b/includes/dkpdf-functions.php
@@ -2,6 +2,8 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
+require_once('dkpdf-cache.php');
+
 /**
 * displays pdf button
 */
@@ -116,7 +118,6 @@ function dkpdf_output_pdf( $query ) {
 
       if( $enable_cache == 'on' or $enable_cache === true ) {
 
-				require_once('dkpdf-cache.php');
 				if($data = dkpdf_cache_get($post->ID)) {
 					error_reporting(E_ALL);
 					$pdfbutton_action = sanitize_option( 'dkpdf_pdfbutton_action', get_option( 'dkpdf_pdfbutton_action', 'open' ) );

--- a/includes/dkpdf-functions.php
+++ b/includes/dkpdf-functions.php
@@ -127,7 +127,7 @@ function dkpdf_output_pdf( $query ) {
 
 						if (!isset($_SERVER['HTTP_ACCEPT_ENCODING']) || empty($_SERVER['HTTP_ACCEPT_ENCODING'])) {
 							// don't use length if server using compression
-							header('Content-Length: ' . strlen($this->buffer));
+							header('Content-Length: ' . strlen($data));
 						}
 
 						header('Content-disposition: inline; filename="' . $name . '"');

--- a/includes/dkpdf-functions.php
+++ b/includes/dkpdf-functions.php
@@ -113,13 +113,11 @@ function dkpdf_output_pdf( $query ) {
 
   if( $pdf ) {
 			global $post;
-			/* define('DKPDF_CACHE', 'on') in wp-config.php saves a few seconds compared to just ticking the box in options */
-      $enable_cache = defined('DKPDF_CACHE') ? DKPDF_CACHE : get_option( 'dkpdf_enable_cache' );
+      $enable_cache = dkpdf_cache_is_enabled();
 
-      if( $enable_cache == 'on' or $enable_cache === true ) {
+      if( $enable_cache ) {
 
 				if($data = dkpdf_cache_get($post->ID)) {
-					error_reporting(E_ALL);
 					$pdfbutton_action = sanitize_option( 'dkpdf_pdfbutton_action', get_option( 'dkpdf_pdfbutton_action', 'open' ) );
 					$title = str_replace( '"', '', apply_filters( 'dkpdf_pdf_filename', get_the_title( $post->ID ) ) );
 					$name = $title . '.pdf';
@@ -263,7 +261,7 @@ function dkpdf_output_pdf( $query ) {
 
       }
 
-      if( $enable_cache == 'on' or $enable_cache === true ) {
+      if( $enable_cache ) {
 				dkpdf_cache_set($post->ID, $mpdf->Output(NULL, \Mpdf\Output\Destination::STRING_RETURN));
 			}
 


### PR DESCRIPTION
Since PDF generation can take some time, I've implemented file cache. 

It's using filesystem for the cache: I've contemplated using wp_cache_* family of functions but:
1. It's not persistent out of the box
2. Storing PDFs in Redis or Memcached is an overkill

File names are salted hashes of post ID. Used salt is LOGGED_IN_SALT, which should be unique per-site and thus, result in unguessable file names (important for non-public posts).

It has two events invalidating the cache:
* Saving the post/page invalidates a single PDF
* Saving dk-pdf settings invalidates all cached PDFs

There is a new setting for enabling/disabling the cache since it may not always be appropriate.

Since the settings are stored using get_option() and it adds a noticeable delay, there's also an alternative way to enable the DKPDF cache:

    define('DKPDF_CACHE', 'on');

It's faster by 300ms on one server and 1s on another.