### PR TITLE
Updated mpdf to latest version to work with PHP 7 and 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "dinamiko/dk-pdf",
     "require": {
-        "mpdf/mpdf": "^7.0"
+        "mpdf/mpdf": "^8.1.0"
     }
 }


### PR DESCRIPTION
Other possible solution would be to update the mpdf (7.0) as I did here https://github.com/wwwxkz/dk-pdf, not the best option, but it keeps PHP requirements below PHP 7