### PR TITLE
Generate pdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ fonts/*
 wordpress
 docs
 build
+uploads
 
 # Playwright
 /test-results/

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -10,7 +10,8 @@
   "mappings": {
     "wp-content/plugins/disable-rest-permissions": "./plugins/disable-rest-permissions",
     "wp-content/plugins/dk-pdf-storage": "./plugins/dk-pdf-storage",
-    "wp-content/themes/storefront-child": "./themes/storefront-child"
+    "wp-content/themes/storefront-child": "./themes/storefront-child",
+    "wp-content/uploads": "./uploads"
   },
   "phpVersion": "8.2",
   "config": {

--- a/api.php
+++ b/api.php
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @param array $args    Optional arguments:
  *                       - 'output_path' (string) Full file path for the PDF.
  *                       - 'title' (string) Override PDF document title/filename.
+ *                       - 'format' (string) Page size, e.g. 'A4', 'Letter', 'A4-L'.
  * @return string|WP_Error File path on success, WP_Error on failure.
  */
 function dkpdf_generate( int $post_id, array $args = [] ) {

--- a/api.php
+++ b/api.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * DK PDF Public API
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Generate a PDF for a post and save it to a file.
+ *
+ * Must be called after plugins_loaded (priority 10).
+ *
+ * Usage:
+ *   $path = dkpdf_generate( 42 );
+ *   $path = dkpdf_generate( 42, [ 'output_path' => '/path/to/file.pdf' ] );
+ *   $path = dkpdf_generate( 42, [ 'title' => 'Custom Title' ] );
+ *
+ * @param int   $post_id The post ID to generate PDF for.
+ * @param array $args    Optional arguments:
+ *                       - 'output_path' (string) Full file path for the PDF.
+ *                       - 'title' (string) Override PDF document title/filename.
+ * @return string|WP_Error File path on success, WP_Error on failure.
+ */
+function dkpdf_generate( int $post_id, array $args = [] ) {
+	try {
+		$container = \Dinamiko\DKPDF\Container::container();
+	} catch ( \LogicException $e ) {
+		return new WP_Error(
+			'plugin_not_initialized',
+			__( 'DK PDF plugin is not initialized yet. Make sure to call this function after plugins_loaded.', 'dkpdf' )
+		);
+	}
+
+	$generator = $container->get( 'pdf.programmatic_generator' );
+
+	return $generator->generate( $post_id, $args );
+}

--- a/dk-pdf.php
+++ b/dk-pdf.php
@@ -72,5 +72,7 @@ add_action(
 		plugin()->boot();
 
 		Container::init( plugin()->container() );
+
+		require_once __DIR__ . '/api.php';
 	}
 );

--- a/modules/PDF/DocumentBuilder.php
+++ b/modules/PDF/DocumentBuilder.php
@@ -35,8 +35,8 @@ class DocumentBuilder {
 		$this->outputPdf( $mpdf, $title );
 	}
 
-	private function createMpdfInstance(): Mpdf {
-		$config = $this->getMpdfConfig();
+	private function createMpdfInstance( ?string $format = null ): Mpdf {
+		$config = $this->getMpdfConfig( $format );
 		return new Mpdf( $config );
 	}
 
@@ -142,15 +142,19 @@ class DocumentBuilder {
 		return $fontdata;
 	}
 
-	private function getMpdfConfig(): array {
+	private function getMpdfConfig( ?string $format = null ): array {
+		if ( $format === null ) {
+			$format = get_option( 'dkpdf_page_orientation' ) == 'horizontal' ?
+				apply_filters( 'dkpdf_pdf_format', 'A4' ) . '-L' :
+				apply_filters( 'dkpdf_pdf_format', 'A4' );
+		}
+
 		// Configure PDF options from settings
 		$config = array(
 			'tempDir'                 => apply_filters( 'dkpdf_mpdf_temp_dir', realpath( __DIR__ . '/../..' ) . '/tmp' ),
 			'default_font_size'       => get_option( 'dkpdf_font_size', '12' ),
 			'default_font'            => $this->getSelectedFont(),
-			'format'                  => get_option( 'dkpdf_page_orientation' ) == 'horizontal' ?
-				apply_filters( 'dkpdf_pdf_format', 'A4' ) . '-L' :
-				apply_filters( 'dkpdf_pdf_format', 'A4' ),
+			'format'                  => $format,
 			'margin_left'             => get_option( 'dkpdf_margin_left', '15' ),
 			'margin_right'            => get_option( 'dkpdf_margin_right', '15' ),
 			'margin_top'              => get_option( 'dkpdf_margin_top', '50' ),
@@ -283,10 +287,10 @@ class DocumentBuilder {
 	 * @return string The file path where the PDF was saved
 	 * @throws \Exception If PDF generation fails
 	 */
-	public function generateToFile( string $title, string $file_path ): string {
+	public function generateToFile( string $title, string $file_path, ?string $format = null ): string {
 		require_once realpath( __DIR__ . '/../..' ) . '/vendor/autoload.php';
 
-		$mpdf = $this->createMpdfInstance();
+		$mpdf = $this->createMpdfInstance( $format );
 		$this->configureMpdfSettings( $mpdf );
 		$this->addContentToMpdf( $mpdf );
 		$this->setDocumentProperties( $mpdf, $title );

--- a/modules/PDF/DocumentBuilder.php
+++ b/modules/PDF/DocumentBuilder.php
@@ -275,6 +275,29 @@ class DocumentBuilder {
 		$mpdf->SetAuthor( apply_filters( 'dkpdf_pdf_author', get_bloginfo( 'name' ) ) );
 	}
 
+	/**
+	 * Generate a PDF document and save it to a file
+	 *
+	 * @param string $title     The title/filename for the PDF
+	 * @param string $file_path The full file path to save the PDF to
+	 * @return string The file path where the PDF was saved
+	 * @throws \Exception If PDF generation fails
+	 */
+	public function generateToFile( string $title, string $file_path ): string {
+		require_once realpath( __DIR__ . '/../..' ) . '/vendor/autoload.php';
+
+		$mpdf = $this->createMpdfInstance();
+		$this->configureMpdfSettings( $mpdf );
+		$this->addContentToMpdf( $mpdf );
+		$this->setDocumentProperties( $mpdf, $title );
+
+		do_action( 'dkpdf_before_output', $mpdf, $title );
+
+		$mpdf->Output( $file_path, 'F' );
+
+		return $file_path;
+	}
+
 	private function outputPdf( Mpdf $mpdf, string $title ): void {
 		// Clean any previous output before sending PDF
 		if ( ob_get_level() ) {

--- a/modules/PDF/PDFModule.php
+++ b/modules/PDF/PDFModule.php
@@ -13,13 +13,18 @@ class PDFModule implements ServiceModule, ExecutableModule {
 
 	public function services(): array {
 		return [
-			'pdf.context_manager'  => static fn( $container ) => new ContextManager(),
-			'pdf.title_resolver'   => static fn( $container ) => new TitleResolver(),
-			'pdf.document_builder' => static fn( $container ) => new DocumentBuilder(
+			'pdf.context_manager'          => static fn( $container ) => new ContextManager(),
+			'pdf.title_resolver'           => static fn( $container ) => new TitleResolver(),
+			'pdf.document_builder'         => static fn( $container ) => new DocumentBuilder(
 				$container->get( 'template.renderer' )
 			),
-			'pdf.generator'        => static fn( $container ) => new Generator(
+			'pdf.generator'                => static fn( $container ) => new Generator(
 				$container->get( 'template.renderer' ),
+				$container->get( 'pdf.document_builder' ),
+				$container->get( 'pdf.context_manager' ),
+				$container->get( 'pdf.title_resolver' )
+			),
+			'pdf.programmatic_generator'   => static fn( $container ) => new ProgrammaticGenerator(
 				$container->get( 'pdf.document_builder' ),
 				$container->get( 'pdf.context_manager' ),
 				$container->get( 'pdf.title_resolver' )

--- a/modules/PDF/ProgrammaticGenerator.php
+++ b/modules/PDF/ProgrammaticGenerator.php
@@ -1,0 +1,127 @@
+<?php
+declare( strict_types=1 );
+
+namespace Dinamiko\DKPDF\PDF;
+
+class ProgrammaticGenerator {
+
+	private DocumentBuilder $documentBuilder;
+	private ContextManager $contextManager;
+	private TitleResolver $titleResolver;
+
+	public function __construct(
+		DocumentBuilder $documentBuilder,
+		ContextManager $contextManager,
+		TitleResolver $titleResolver
+	) {
+		$this->documentBuilder = $documentBuilder;
+		$this->contextManager  = $contextManager;
+		$this->titleResolver   = $titleResolver;
+	}
+
+	/**
+	 * Generate a PDF for a post and save it to a file
+	 *
+	 * @param int   $post_id The post ID to generate PDF for.
+	 * @param array $args    Optional arguments:
+	 *                       - 'output_path' (string) Full file path for the PDF.
+	 *                       - 'title' (string) Override PDF document title.
+	 * @return string|\WP_Error File path on success, WP_Error on failure.
+	 */
+	public function generate( int $post_id, array $args = [] ) {
+		$backup = $this->backupGlobals();
+
+		try {
+			// Set the pdf query var so legacy templates work
+			set_query_var( 'pdf', (string) $post_id );
+
+			$result = $this->contextManager->setupContext( $post_id );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+
+			$title = $args['title'] ?? $this->titleResolver->resolveTitle();
+
+			$output_path = $this->resolveOutputPath( $post_id, $title, $args );
+			if ( is_wp_error( $output_path ) ) {
+				return $output_path;
+			}
+
+			$dir = dirname( $output_path );
+			if ( ! wp_mkdir_p( $dir ) ) {
+				return new \WP_Error(
+					'directory_creation_failed',
+					sprintf(
+						/* translators: %s: directory path */
+						__( 'Could not create directory: %s', 'dkpdf' ),
+						$dir
+					)
+				);
+			}
+
+			return $this->documentBuilder->generateToFile( $title, $output_path );
+		} catch ( \Exception $e ) {
+			return new \WP_Error(
+				'pdf_generation_failed',
+				sprintf(
+					/* translators: %s: error message */
+					__( 'PDF generation failed: %s', 'dkpdf' ),
+					$e->getMessage()
+				)
+			);
+		} finally {
+			$this->restoreGlobals( $backup );
+		}
+	}
+
+	/**
+	 * @return string|\WP_Error
+	 */
+	private function resolveOutputPath( int $post_id, string $title, array $args ) {
+		if ( ! empty( $args['output_path'] ) ) {
+			return apply_filters( 'dkpdf_programmatic_output_path', $args['output_path'], $post_id, $args );
+		}
+
+		$upload_dir = wp_upload_dir();
+		if ( ! empty( $upload_dir['error'] ) ) {
+			return new \WP_Error(
+				'upload_dir_error',
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Upload directory error: %s', 'dkpdf' ),
+					$upload_dir['error']
+				)
+			);
+		}
+
+		$dir             = trailingslashit( $upload_dir['basedir'] ) . 'dkpdf';
+		$sanitized_title = sanitize_file_name( $title );
+		$filename        = sprintf( '%d-%s-%d.pdf', $post_id, $sanitized_title, time() );
+		$file_path       = trailingslashit( $dir ) . $filename;
+
+		return apply_filters( 'dkpdf_programmatic_output_path', $file_path, $post_id, $args );
+	}
+
+	private function backupGlobals(): array {
+		global $post, $wp_query;
+
+		return [
+			'post'          => $post,
+			'wp_query'      => clone $wp_query,
+			'pdf_query_var' => get_query_var( 'pdf', '' ),
+		];
+	}
+
+	private function restoreGlobals( array $backup ): void {
+		global $post, $wp_query;
+
+		$post     = $backup['post'];
+		$wp_query = $backup['wp_query'];
+
+		set_query_var( 'pdf', $backup['pdf_query_var'] );
+
+		if ( $post ) {
+			setup_postdata( $post );
+		}
+	}
+}

--- a/modules/PDF/ProgrammaticGenerator.php
+++ b/modules/PDF/ProgrammaticGenerator.php
@@ -26,6 +26,7 @@ class ProgrammaticGenerator {
 	 * @param array $args    Optional arguments:
 	 *                       - 'output_path' (string) Full file path for the PDF.
 	 *                       - 'title' (string) Override PDF document title.
+	 *                       - 'format' (string) Page size, e.g. 'A4', 'Letter', 'A4-L'.
 	 * @return string|\WP_Error File path on success, WP_Error on failure.
 	 */
 	public function generate( int $post_id, array $args = [] ) {
@@ -59,7 +60,9 @@ class ProgrammaticGenerator {
 				);
 			}
 
-			return $this->documentBuilder->generateToFile( $title, $output_path );
+			$format = $args['format'] ?? null;
+
+			return $this->documentBuilder->generateToFile( $title, $output_path, $format );
 		} catch ( \Exception $e ) {
 			return new \WP_Error(
 				'pdf_generation_failed',


### PR DESCRIPTION
This PR allows generate PDFs programmatically.

### Usage
```php
// Basic — saves to wp-content/uploads/dkpdf/
$path = dkpdf_generate( 42 );

// Custom output path
$path = dkpdf_generate( 42, [ 'output_path' => '/path/to/invoice.pdf' ] );

// Custom title
$path = dkpdf_generate( 42, [ 'title' => 'Invoice #42' ] );

// Error handling
if ( is_wp_error( $path ) ) {
   error_log( $path->get_error_message() );
}
```